### PR TITLE
Support a schema.json with read-only `options` key

### DIFF
--- a/dist/command.js
+++ b/dist/command.js
@@ -127,7 +127,7 @@ const prettyPrintCommand = command => {
     case DeleteIndex.type:
       return `Delete Index "${command.indexName}" from "${command.collection}"`;
     case UpdateIndex.type:
-      return `Update Index "${command.definition.indexName}" on "${command.definition.className}"`;
+      return `Update Index "${command.name}" on "${command.collection}"`;
     case AddFunction.type:
       return `Add Function "${command.definition.functionName}"`;
     case DeleteFunction.type:

--- a/src/command.js
+++ b/src/command.js
@@ -260,7 +260,7 @@ const prettyPrintCommand = (command: Command): string => {
     case DeleteIndex.type:
       return `Delete Index "${command.indexName}" from "${command.collection}"`;
     case UpdateIndex.type:
-      return `Update Index "${command.definition.indexName}" on "${command.definition.className}"`;
+      return `Update Index "${command.name}" on "${command.collection}"`;
     case AddFunction.type:
       return `Add Function "${command.definition.functionName}"`;
     case DeleteFunction.type:


### PR DESCRIPTION
NOTE: This is a read-only PR.

`parse-server` is not set up to handle storing the options of a created index and I think it's not worth the effort to patch it especially since we are using `parseconfig` with `--ignore-indexes`

Here, we support our new format on `schema.json` which stores an indexes options in addition to the key.