### PR TITLE
use /usr/bin/env bash instead of /usr/bin/bash in shebang

### DIFF
--- a/integration-tests
+++ b/integration-tests
@@ -1,4 +1,4 @@
-#! /usr/bin/bash
+#! /usr/bin/env bash
 
 docker-compose -f docker-compose-tests.yml up -d
 isup=1

--- a/shebangify
+++ b/shebangify
@@ -1,3 +1,3 @@
-#! /usr/bin/bash
+#! /usr/bin/env bash
 
 cat <(echo -e '#!/usr/bin/env node') dist/parseconfig.js > dist/parseconfig.js_new; mv dist/parseconfig.js_new dist/parseconfig.js


### PR DESCRIPTION
This will determine where bash actually is, rather than assuming.

The default on mac is /bin/bash.